### PR TITLE
add navbar translucency and Get Started button work

### DIFF
--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -1,6 +1,6 @@
 .not-logged-in{
   z-index: 1;
-  background-color: transparent;
+  background-color: rgba(255,255,255,0.15);
   border: 0;
   border-radius: 0;
 }
@@ -23,4 +23,40 @@
   background-color: transparent;
   color: #fff;
   text-shadow: 0 0 1px #000
+}
+
+.not-logged-in-button{
+  font-family: 'Open Sans';
+  background-color: rgba(86, 86, 86, 0.498039);
+  border-color: rgb(255, 255, 255);
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0px;
+}
+
+.not-logged-in-button:hover{
+  font-family: 'Open Sans';
+  background-color: rgba(0, 0, 0, 0.298039);
+  border-color: rgb(255, 255, 255);
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0px;
+}
+
+.not-logged-in-button:active{
+  font-family: 'Open Sans';
+  background-color: rgba(0, 0, 0, 0.298039);
+  border-color: rgb(255, 255, 255);
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0px;
+}
+
+.not-logged-in-button:focus{
+  font-family: 'Open Sans';
+  background-color: rgba(0, 0, 0, 0.298039);
+  border-color: rgb(255, 255, 255);
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0px;
 }

--- a/app/views/dashboard/welcome.html.haml
+++ b/app/views/dashboard/welcome.html.haml
@@ -12,5 +12,5 @@
 .row
   = link_to new_user_registration_path do
     .col-md-8.col-md-offset-2
-      .btn.btn-primary.btn-block.btn-lg
+      .btn.btn-primary.btn-block.btn-lg.not-logged-in-button
         Get Started

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
 	  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
 	  <%= csrf_meta_tags %>
 	  <meta name="viewport" content="width=device-width, initial-scale=1">
+	  <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 	</head>
 
 	<body>


### PR DESCRIPTION
@alexneigher added some styling to the Get Started button so it's not so bootstrappy. can probably extend this to the rest of the navbar probably too, but wanted to get your thoughts first.

is there a better way to do the :active :hover :focus? that seemed like a bit of overkill.