### PR TITLE
fix/add logic if no attachment for given id

### DIFF
--- a/app/models/style.rb
+++ b/app/models/style.rb
@@ -54,7 +54,10 @@ class Style < ActiveRecord::Base
 
     return nil unless attachments.any?
     if default_attachment_id
-      attachments.find(default_attachment_id).photo.url(size)
+      a = attachments.find_by_id(default_attachment_id)
+      unless a.nil?
+        a.photo.url(size)
+      end
     else
       attachments.first.photo.url(size)
     end


### PR DESCRIPTION
@alexneigher lmk what you think

Was getting the attached error a lot.

Using .find_by_* returns nil when no record is found rather than .find() which returns ActiveRecord::RecordNotFound. Then if there's no attachment for the id stored do nothing, i.e. don't call .photo().

![image](https://user-images.githubusercontent.com/9066033/27257173-4b0011d6-5381-11e7-8b85-ef46251caef3.png)
